### PR TITLE
FA-377 Implement Audit Logging BE Endpoints

### DIFF
--- a/webhook/__init__.py
+++ b/webhook/__init__.py
@@ -6,7 +6,7 @@ import os
 import stripe
 
 
-from shared.util import handle_subscription_logs, update_organization_subscription, disable_organization_active_subscription, enable_organization_subscription, update_subscription_logs
+from shared.util import handle_new_subscription_logs, handle_subscription_logs, update_organization_subscription, disable_organization_active_subscription, enable_organization_subscription, update_subscription_logs
 
 LOGLEVEL = os.environ.get("LOGLEVEL", "DEBUG").upper()
 logging.basicConfig(level=LOGLEVEL)
@@ -19,7 +19,6 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
     
     stripe.api_key = os.getenv("STRIPE_API_KEY")
     endpoint_secret = os.getenv("STRIPE_SIGNING_SECRET")
-    stripe_product_fa=os.getenv("STRIPE_PRODUCT_FA")
 
     event = None
     payload = req.get_body()
@@ -44,15 +43,17 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
     if event["type"] == "checkout.session.completed":
         print("  Webhook received!", event["type"])
         userId = event["data"]["object"]["client_reference_id"]
+        userName = event["data"]["object"].get("metadata", {}).get("userName", "") or ""
         organizationId = event["data"]["object"].get("metadata", {}).get("organizationId", "") or ""
+        organizationName = event["data"]["object"].get("metadata", {}).get("organizationName", "") or ""
         sessionId = event["data"]["object"]["id"]
         subscriptionId = event["data"]["object"]["subscription"]
         paymentStatus = event["data"]["object"]["payment_status"]
-        custom_fields = event["data"]["object"].get("custom_fields", [])
-        organizationName = custom_fields[0]["text"]["value"] if custom_fields else "No name"
+
         expirationDate = event["data"]["object"]["expires_at"]
         try:
             update_organization_subscription(userId, organizationId, subscriptionId, sessionId, paymentStatus, organizationName, expirationDate)
+            handle_new_subscription_logs(userId, organizationId, userName, organizationName)
             logging.info(f"User {userId} updated with subscription {subscriptionId}")
         except Exception as e:
             logging.exception("[webbackend] exception in /api/webhook")
@@ -71,22 +72,21 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
         def determine_action(event):
             data = event.get("data", {}).get("object", {})
             previous_data = event.get("data", {}).get("previous_attributes", {})
-            current_items = data.get("items", {}).get("data", [])
-            previous_items = previous_data.get("items", {}).get("data", [])
             metadata=data.get("metadata",{})
 
+            modification_type= None
+            modified_by="Unknown"
+            modified_by_name="Unknown"
 
-            #Detect when the subscription is new
-            if "status" in previous_data and previous_data["status"] == "incomplete" and data["status"] == "active":
-                current_plan = data.get("plan", {})
-                current_plan_nickname = current_plan.get("nickname", "Unknown")
-                return "New Subscription", None, current_plan_nickname, None, None, None
-
-            #Detect whent the financial assistant is active o disabled
             if "modification_type" in metadata:
                 modification_type = metadata.get("modification_type")
                 modified_by = metadata.get("modified_by", "Unknown")
                 modified_by_name = metadata.get("modified_by_name","Unknown")
+
+            # If modification_type is not received, log the message and do not create anything in the audit
+            if modification_type is None:
+                logging.info("Modification type not received, no audit action created.")
+                return "No action", None, None, modified_by, modified_by_name, None    
 
             if modification_type == "add_financial_assistant":
                 status_financial_assistant = "active"
@@ -106,23 +106,23 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
         action, previous_plan, current_plan, modified_by, modified_by_name, status_financial_assistant = determine_action(event)
         print(f"Action determined: {action}")
 
-        if action =="Subscription Tier Change":
-            print(f"Previous Plan: {previous_plan}")
-            print(f"Current Plan: {current_plan}")
+        if action != "No action":
+            enable_organization_subscription(subscriptionId)
+            update_subscription_logs(subscriptionId, action, previous_plan, current_plan, modified_by, modified_by_name, status_financial_assistant)
 
-        enable_organization_subscription(subscriptionId)
-        update_subscription_logs(subscriptionId, action, previous_plan, current_plan, modified_by, modified_by_name, status_financial_assistant)
     elif event["type"] == "customer.subscription.paused":
         print("  Webhook received!", event["type"])
         subscriptionId = event["data"]["object"]["id"]
         event_type = event["type"].split(".")[-1] # Obtain "paused"
         handle_subscription_logs(subscriptionId, event_type)
         disable_organization_active_subscription(subscriptionId)
+
     elif event["type"] == "customer.subscription.resumed":
         print("  Webhook received!", event["type"])
         event_type = event["type"].split(".")[-1] # Obtain "resumed"
         handle_subscription_logs(subscriptionId, event_type)
         enable_organization_subscription(subscriptionId)
+        
     elif event["type"] == "customer.subscription.deleted":
         print("  Webhook received!", event["type"])
         event_type = event["type"].split(".")[-1] # Obtain "deleted"

--- a/webhook/__init__.py
+++ b/webhook/__init__.py
@@ -68,7 +68,6 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
         subscriptionId = event["data"]["object"]["id"]
         status = event["data"]["object"]["status"]
         expirationDate = event["data"]["object"]["current_period_end"]
-        print(event)
         print(f"expirationDate: => {expirationDate}")
         print(f"Subscription {subscriptionId} updated to status {status}")
 
@@ -99,7 +98,7 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
                 return "Financial Assistant Change", None, None, modified_by,modified_by_name, status_financial_assistant
             
             # Detect subscription level change
-            if "plan" in previous_data and metadata.get("modification_type") == "subscription_tier_change":
+            if "plan" in previous_data and modification_type == "subscription_tier_change":
                 previous_plan = previous_data.get("plan", {}).get("nickname", None)
                 current_plan = data.get("plan", {}).get("nickname", None)
                 return "Subscription Tier Change", previous_plan, current_plan, modified_by,modified_by_name, None


### PR DESCRIPTION
## JIRA Ticket
[FA-377](https://salesfactoryai.atlassian.net/browse/FA-377)

## Description
[
Added endpoints that take webhook states in Stripe and save them in a container for auditing

Three functions were created to perform this task

update_subscription_logs: This is responsible for receiving the Stripe API call "customer.subscription.updated" and checking if it is a plan change, whether or not it activates the financial assistant and creates its history in the auditLogs container

handle_new_subscription_logs: This is responsible for receiving the Stripe API call "checkout.session.complete", and adding it to the auditLogs container when a new subscription is created.

handle_subscription_logs: This is responsible for receiving the other Stripe API calls and creating their history in the auditLogs container

]

## Checklist
- [x] Code review requested
- [ ] Tests completed
- [ ] Documentation updated