### PR TITLE
HOTFIX FA-377-Implement-Audit-Logging-BE-Endpoints-2

### DIFF
--- a/shared/util.py
+++ b/shared/util.py
@@ -1423,7 +1423,7 @@ def handle_new_subscription_logs(userId, organizationId, userName, organizationN
             "modified_by_name":userName,
             "modified_by":userId,
             "organizationName": organizationName,
-            "organizationId": organizationId,
+            "organization_id": organizationId,
             "action": 'Subscription created',
             "changeTime": int(datetime.now(timezone.utc).timestamp()),
         }

--- a/webhook/__init__.py
+++ b/webhook/__init__.py
@@ -111,8 +111,9 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
 
                 return "Subscription Tier Change", previous_plan, current_plan, modified_by, modified_by_name, None
 
-            # Unknown action
-            return "Unknown action", None, None, modified_by,modified_by_name, None
+            # If modification_type does not match any of the above, do not take any action.
+            logging.info(f"Unknown modification type: {modification_type}. No action taken.")
+            return "No action", None, None, modified_by, modified_by_name, None
         
         action, previous_plan, current_plan, modified_by, modified_by_name, status_financial_assistant = determine_action(event)
         print(f"Action determined: {action}")


### PR DESCRIPTION
*HOTFIX change the name of the parameter sent from "organizationId" to "organization_id" to avoid problems with the audit

*HOTFIX make it so that if modification_type does not match "add_financial_assistant", "remove_financial_assistant", "Subcription_tier_change" does not create an "unknown" data in the DB