### PR TITLE
Update get_conversation_data method call with type parameter

### DIFF
--- a/financial_orc/orchestrator.py
+++ b/financial_orc/orchestrator.py
@@ -178,7 +178,7 @@ class FinancialOrchestrator:
         try:
             # Load conversation state
             logging.info(f"[financial-orc] Loading conversation data")
-            conversation_data = get_conversation_data(conversation_id)
+            conversation_data = get_conversation_data(conversation_id, type="financial")
             logging.info(f"[financial-orc] Loading memory")
             memory = self._load_memory(
                 conversation_data.get("memory_data", ""))


### PR DESCRIPTION
- Modify get_conversation_data method call in financial orchestrator
- Add 'type="financial"' parameter to specify conversation data type