### PR TITLE
FA - 465 Add indexer run trigger functionality after report generation

### DIFF
--- a/monthly_scheduler/__init__.py
+++ b/monthly_scheduler/__init__.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Dict, List
 from shared.cosmo_data_loader import CosmosDBLoader
 from enum import Enum
-
+from shared.util import trigger_indexer_run
 # logger setting
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -129,9 +129,15 @@ def generate_report(
             json=payload,
             timeout=TIMEOUT_SECONDS,
         )
-        logger.debug(
-            f"Received response for report generation request for {report_topic}"
-        )
+        if response.status_code == 200:
+            logger.debug(f"Received response for report generation request for {report_topic}")
+            response_json = response.json()
+            # Trigger indexer run if report generation was successful
+            if response_json.get("status") == "success":
+                if trigger_indexer_run():
+                    logger.info(f"Successfully triggered indexer run after report generation for {report_topic}")
+                else:
+                    logger.error(f"Failed to trigger indexer run after report generation for {report_topic}")
         return response.json()
 
     try:

--- a/shared/util.py
+++ b/shared/util.py
@@ -1556,3 +1556,37 @@ def get_invitation(invited_user_email):
     except Exception as e:
         logging.error(f"[get_invitation] something went wrong. {str(e)}")
     return invitation
+
+def trigger_indexer_run() -> bool:
+    """Trigger Azure AI Search indexer run to process new documents"""
+    try:
+        search_service = os.getenv("AZURE_SEARCH_SERVICE")
+        indexer_name = os.getenv("AZURE_SEARCH_INDEXER_NAME")
+        api_version = os.getenv("AZURE_SEARCH_API_VERSION", "2023-11-01")
+        api_key = os.getenv("AZURE_AI_SEARCH_API_KEY")
+
+        if not all([search_service, indexer_name, api_key]):
+            logging.error("Missing required environment variables for indexer run")
+            return False
+
+        headers = {
+            "Content-Type": "application/json",
+            "api-key": api_key
+        }
+
+        # Endpoint to run the indexer
+        indexer_endpoint = f"https://{search_service}.search.windows.net/indexers/{indexer_name}/run?api-version={api_version}"
+        
+        logging.info(f"Triggering indexer run for {indexer_name}")
+        response = requests.post(indexer_endpoint, headers=headers)
+        
+        if response.status_code == 202:  # 202 is the expected status code for indexer run
+            logging.info(f"Successfully triggered indexer run for {indexer_name}")
+            return True
+        else:
+            logging.error(f"Failed to trigger indexer run. Status code: {response.status_code}, Response: {response.text}")
+            return False
+
+    except Exception as e:
+        logging.error(f"Error triggering indexer run: {str(e)}")
+        return False

--- a/shared/util.py
+++ b/shared/util.py
@@ -1561,7 +1561,7 @@ def trigger_indexer_run() -> bool:
     """Trigger Azure AI Search indexer run to process new documents"""
     try:
         search_service = os.getenv("AZURE_SEARCH_SERVICE")
-        indexer_name = os.getenv("AZURE_SEARCH_INDEXER_NAME")
+        indexer_name = os.getenv("AZURE_FINANCIAL_SEARCH_INDEXER_NAME")
         api_version = os.getenv("AZURE_SEARCH_API_VERSION", "2023-11-01")
         api_key = os.getenv("AZURE_AI_SEARCH_API_KEY")
 


### PR DESCRIPTION
- Introduced `trigger_indexer_run` function in `shared/util.py` to handle Azure AI Search indexer runs.
- Updated `generate_report` function in both `monthly_scheduler/__init__.py` and `weekly_scheduler/__init__.py` to trigger the indexer run upon successful report generation.
- Added logging for success and failure cases of the indexer trigger.