### PR TITLE
FA 916 Chat History not loading in production

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -96,6 +96,7 @@ async def stream_response(req: Request) -> StreamingResponse:
     req_body = await req.json()
     question = req_body.get("question")
     conversation_id = req_body.get("conversation_id")
+    user_timezone = req_body.get("user_timezone")
     client_principal_id = req_body.get("client_principal_id")
     client_principal_name = req_body.get("client_principal_name")
     client_principal_organization = req_body.get("client_principal_organization")
@@ -139,6 +140,7 @@ async def stream_response(req: Request) -> StreamingResponse:
                     question=question,
                     user_info=client_principal,
                     user_settings=settings,
+                    user_timezone=user_timezone,
                 ),
                 media_type="text/event-stream",
             )

--- a/orc/new_orchestrator.py
+++ b/orc/new_orchestrator.py
@@ -231,6 +231,7 @@ class ConversationOrchestrator:
         question: str,
         user_info: dict,
         user_settings: dict = None,
+        user_timezone: str | None = None,
     ):
         """Generate response with real-time progress streaming."""
         start_time = time.time()
@@ -252,7 +253,7 @@ class ConversationOrchestrator:
         try:
             # Load conversation state
             logging.info(f"[orchestrator] Loading conversation data for ID: {conversation_id}")
-            conversation_data = get_conversation_data(conversation_id)
+            conversation_data = get_conversation_data(conversation_id, user_timezone=user_timezone)
             memory = self._load_memory(conversation_data.get("memory_data", ""))
 
             # Progress for graph setup


### PR DESCRIPTION
## JIRA Ticket
[FA-916](https://salesfactoryai.atlassian.net/browse/FA-916)

## Description
[The real problem was that conversations were being saved with UTC time, and when the next day began, the frontend filter was unable to recognize those conversations.]

## Checklist
- [ ] Code review requested
- [ ] Tests completed
- [ ] Documentation updated