### PR TITLE
Feat/doc-chat-blob-names-cache-reuse

### DIFF
--- a/DOCUMENT_CHAT_WORKFLOW.md
+++ b/DOCUMENT_CHAT_WORKFLOW.md
@@ -1,0 +1,155 @@
+# Document Chat Workflow
+
+## Overview
+This document explains how the document chat workflow is implemented end to end. Users can attach up to three documents in the UI; the backend then routes the query to the document chat MCP tool, reuses prior file IDs when possible, and persists state to Cosmos DB for continuity across turns.
+
+## End‑to‑End Flow
+1. UI sends `question`, `conversation_id`, and `blob_names` (array of document blob names).
+2. Function app extracts `blob_names` and passes them to the orchestrator.
+3. Orchestrator normalizes `blob_names` and builds the conversation graph.
+4. Graph routes to tools immediately when `blob_names` are present in the runtime state (passed via `ainvoke`).
+5. MCP executor forces the `document_chat` tool, validates cache vs. UI input, and calls the tool.
+6. Context builder adds the tool’s `answer` to context docs and overwrites `uploaded_file_refs` in state.
+7. Graph returns state; orchestrator saves `uploaded_file_refs` and other metadata to Cosmos.
+
+## Storage Layout (UI/ingestion expectation)
+```
+container_name/
+  organization_id/
+    user_id/
+      conversation_id/
+        file_1_id
+        file_2_id
+        file_3_id   # UI enforces max 3
+```
+
+## MCP Contract
+
+Request arguments to `document_chat` (sent by MCP executor):
+```python
+{
+    "question": state.question,
+    "document_names": state.blob_names,            # always present when tool is used
+    # only present if validation passes
+    "cached_file_info": state.uploaded_file_refs,
+}
+```
+
+Response shape expected from `document_chat`:
+```python
+{
+    "answer": "...",
+    "files": [
+        {"file_id": "file-abc123", "blob_name": "doc1.pdf"},
+        {"file_id": "file-def456", "blob_name": "doc2.pdf"}
+    ],
+    "metadata": { ... }
+}
+```
+
+## Implementation Map (current code)
+
+- Conversation state
+  - `orc/graphs/models.py`: `ConversationState` includes `blob_names: List[str]` and `uploaded_file_refs: List[Dict[str, str]]`.
+
+- HTTP entrypoint
+  - `function_app.py`: `/api/orc` extracts `blob_names` from JSON and passes them to the orchestrator (a small default list is present for local testing).
+
+- Orchestrator
+  - `orc/new_orchestrator.py`:
+    - `generate_response_with_progress(...)` accepts and normalizes `blob_names`.
+    - Passes `blob_names` only in the `agent.ainvoke({"question", "blob_names"}, ...)` payload; the graph uses this to seed `state.blob_names`.
+    - Builds `ConversationState` from the graph’s result and includes `uploaded_file_refs`.
+    - Appends `uploaded_file_refs` and `last_mcp_tool_used` to the assistant message in Cosmos history.
+
+- Graph and routing
+  - `orc/graphs/main_2.py`:
+    - `GraphBuilder` no longer accepts `blob_names`.
+    - `_route_decision(...)` returns `tool_choice` when `state.blob_names` (from `ainvoke` input) is present.
+    - `_return_state(...)` includes `uploaded_file_refs` in the returned dict.
+
+- History initialization
+  - `orc/graphs/query_planner.py` uses utilities from `orc/graphs/utils.py` to extract `code_thread_id`, `last_mcp_tool_used`, and `uploaded_file_refs` from Cosmos history during rewrite; these seed the state at the start of each turn.
+
+- MCP tool planning and execution
+  - `orc/graphs/mcp_executor.py`:
+    - `get_tool_calls(...)` forces `document_chat` if `state.blob_names` is non‑empty (skips LLM tool planning).
+    - `_configure_document_chat_args(...)` compares `state.blob_names` with `state.uploaded_file_refs[*].blob_name`:
+      - Exact set match → include `cached_file_info` for file ID reuse.
+      - Mismatch or empty cache → omit `cached_file_info` to process fresh documents.
+    - When `state.blob_names` is empty, `document_chat` is excluded from the set of tools bound to the LLM during planning to avoid invalid schema binding; the LLM will only choose among other available tools.
+
+- Context building
+  - `orc/graphs/context_builder.py`: for `document_chat`, appends `result["answer"]` to context docs and overwrites `state.uploaded_file_refs` with `result["files"]`.
+
+## Validation and Reuse Rules
+- Exact set match on blob names (case‑sensitive) controls reuse; order is ignored.
+- No partial reuse — any difference triggers fresh processing.
+- Always overwrite `uploaded_file_refs` with the latest `files` from the tool.
+- UI enforces up to 3 files; backend accepts any length but uses what the UI provides.
+
+## Data Flow Summary
+
+1) Request path
+```
+UI → Function App → Orchestrator → GraphBuilder → ConversationState (with `blob_names` provided via `ainvoke`)
+```
+
+2) Validation path
+```
+state.blob_names  vs  state.uploaded_file_refs[*].blob_name  →  cached_file_info
+```
+
+3) Response path
+```
+MCP Response {answer, files} → ContextBuilder → state.uploaded_file_refs overwrite → _return_state → Cosmos
+```
+
+## Example Payloads
+
+- HTTP request to `/api/orc` (body excerpt):
+```json
+{
+  "question": "Summarize the contract differences",
+  "conversation_id": "<uuid>",
+  "blob_names": ["doc1.pdf", "doc2.pdf"]
+}
+```
+
+- Tool args sent to MCP `document_chat` on a cache hit:
+```json
+{
+  "question": "...question...",
+  "document_names": ["doc1.pdf", "doc2.pdf"],
+  "cached_file_info": [
+    {"file_id": "file-abc123", "blob_name": "doc1.pdf"},
+    {"file_id": "file-def456", "blob_name": "doc2.pdf"}
+  ]
+}
+```
+
+## Testing Scenarios
+
+1) First upload (no cache)
+- Input: `blob_names=["doc1.pdf"]`, history contains no `uploaded_file_refs`.
+- Expect: send only `document_names`; tool returns `files`; state overwrites `uploaded_file_refs`.
+
+2) Same documents (cache hit)
+- Input: `blob_names=["doc1.pdf"]`, history `uploaded_file_refs=[{"file_id":"abc","blob_name":"doc1.pdf"}]`.
+- Expect: include `cached_file_info`; tool reuses file ID; state overwrites with returned `files`.
+
+3) Different documents (cache miss)
+- Input: `blob_names=["doc2.pdf"]`, history refs for `doc1.pdf`.
+- Expect: omit `cached_file_info`; process fresh; overwrite with new refs.
+
+4) Expired files (tool handles)
+- Input: cache hit scenario but IDs expired on MCP side.
+- Expect: server detects expiration; falls back to fresh processing; returns new IDs; overwrite state.
+
+## Notes and Limitations
+- `function_app.py` includes a small default `blob_names` list for local testing; clients should always pass their own array.
+- The 3‑file limit is enforced in the UI; backend logic does not hard‑enforce it.
+- Blob name comparison is case‑sensitive to avoid ambiguous reuse.
+
+## Status
+The document chat workflow described above is fully implemented and live in the codebase outlined in the Implementation Map.

--- a/orc/graphs/constants.py
+++ b/orc/graphs/constants.py
@@ -13,12 +13,14 @@ SECRET_MCP_FUNCTION_KEY = "mcp-host--functionkey"
 TOOL_AGENTIC_SEARCH = "agentic_search"
 TOOL_DATA_ANALYST = "data_analyst"
 TOOL_WEB_FETCH = "web_fetch"
+TOOL_DOCUMENT_CHAT="document_chat"
 
 # Mapping from tool name to progress step
 TOOL_PROGRESS_STEP = {
     TOOL_AGENTIC_SEARCH: ProgressSteps.AGENTIC_SEARCH,
     TOOL_DATA_ANALYST: ProgressSteps.DATA_ANALYSIS,
     TOOL_WEB_FETCH: ProgressSteps.WEB_FETCH,
+    TOOL_DOCUMENT_CHAT: ProgressSteps.DOCUMENT_CHAT
 }
 
 # Display names for tools
@@ -26,4 +28,5 @@ TOOL_DISPLAY_NAME = {
     TOOL_AGENTIC_SEARCH: "Agentic Search",
     TOOL_DATA_ANALYST: "Data Analyst",
     TOOL_WEB_FETCH: "Web Fetch",
+    TOOL_DOCUMENT_CHAT: "Document Chat"
 }

--- a/orc/graphs/context_builder.py
+++ b/orc/graphs/context_builder.py
@@ -6,6 +6,7 @@ from orc.graphs.utils import clean_chat_history_for_llm
 from orc.graphs.constants import (
     TOOL_AGENTIC_SEARCH,
     TOOL_DATA_ANALYST,
+    TOOL_DOCUMENT_CHAT,
     TOOL_WEB_FETCH,
 )
 
@@ -21,9 +22,7 @@ class ContextBuilder:
 
     def _get_org_data(self, key: str, label: str) -> str:
         value = self.organization_data.get(key, "")
-        logger.info(
-            f"[Org Data] Retrieved '{label}' (present={bool(value)})"
-        )
+        logger.info(f"[Org Data] Retrieved '{label}' (present={bool(value)})")
         return value
 
     def build_organization_context_prompt(self, history: List[dict]) -> str:
@@ -108,17 +107,33 @@ class ContextBuilder:
             name = tool_call.get("name")
             if name == TOOL_AGENTIC_SEARCH and isinstance(result, dict):
                 docs.append(result.get("results", result))
+
             elif name == TOOL_DATA_ANALYST and isinstance(result, dict):
                 docs.append(result.get("last_agent_message", result))
                 blob_urls = result.get("blob_urls")
-                if isinstance(blob_urls, list) and blob_urls and isinstance(blob_urls[0], dict):
+                if (
+                    isinstance(blob_urls, list)
+                    and blob_urls
+                    and isinstance(blob_urls[0], dict)
+                ):
                     blob_path = blob_urls[0].get("blob_path")
                     if blob_path:
                         logger.info(f"[MCP] Adding blob path to context: {blob_path}")
-                        docs.append(f"Here is the graph/visualization link: \n\n{blob_path}")
+                        docs.append(
+                            f"Here is the graph/visualization link: \n\n{blob_path}"
+                        )
+
             elif name == TOOL_WEB_FETCH and isinstance(result, dict):
                 web_content = result.get("content")
                 docs.append(web_content if web_content else result)
 
-        return docs
+            elif name == TOOL_DOCUMENT_CHAT and isinstance(result, dict):
+                docs.append(result.get("answer", result))
+                files = result.get("files", [])
+                if files and isinstance(files, list):
+                    state.uploaded_file_refs = files
+                    logger.info(
+                        f"[MCP] Updated uploaded_file_refs with {len(files)} files"
+                    )
 
+        return docs

--- a/orc/graphs/main_2.py
+++ b/orc/graphs/main_2.py
@@ -32,7 +32,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     stream=sys.stdout,
-    force=True,  
+    force=True,
 )
 
 logger = logging.getLogger(__name__)
@@ -84,12 +84,10 @@ class GraphConfig:
         max_tokens (int): Maximum number of tokens for the model output. Default is 200000.
     """
 
-    azure_api_version: str = (
-        "2025-04-01-preview"  
-    )   
-    azure_deployment: str = "gpt-4.1"   
-    support_model_deployment: str = "gpt-5-nano"  
-    support_model_reasoning_effort: str = "low"  
+    azure_api_version: str = "2025-04-01-preview"
+    azure_deployment: str = "gpt-4.1"
+    support_model_deployment: str = "gpt-5-nano"
+    support_model_reasoning_effort: str = "low"
 
     retriever_top_k: int = 5
     reranker_threshold: float = 2
@@ -152,9 +150,7 @@ class GraphBuilder:
                 f"[GraphBuilder Init] Successfully retrieved conversation data for ID: {conversation_id}"
             )
         except Exception:
-            logger.exception(
-                "[GraphBuilder Init] Failed to retrieve conversation data"
-            )
+            logger.exception("[GraphBuilder Init] Failed to retrieve conversation data")
             logger.warning(
                 "[GraphBuilder Init] Using empty conversation data as fallback"
             )
@@ -361,6 +357,7 @@ class GraphBuilder:
             "tool_results": state.tool_results,
             "code_thread_id": updated_thread_id,
             "last_mcp_tool_used": last_mcp_tool_used,
+            "uploaded_file_refs": state.uploaded_file_refs,
         }
 
     def build(self, memory) -> StateGraph:
@@ -430,9 +427,17 @@ class GraphBuilder:
 
     def _route_decision(self, state: ConversationState) -> str:
         """Route query based on knowledge requirement."""
+        # If documents are present, always use tools 
+        if hasattr(state, "blob_names") and state.blob_names:
+            logger.info(
+                f"Documents present ({len(state.blob_names)} files), routing to tool_choice"
+            )
+            return "tool_choice"
+
+        # Original logic for non-document queries
         decision = "tool_choice" if state.requires_retrieval else "return"
         logger.info(
-            f"[Route Decision] Routing to: '{decision}' (requires_retrieval: {state.requires_retrieval})"
+            f"No documents, routing to: '{decision}' (requires_retrieval: {state.requires_retrieval})"
         )
         return decision
 

--- a/orc/graphs/mcp_executor.py
+++ b/orc/graphs/mcp_executor.py
@@ -15,6 +15,7 @@ from orc.graphs.constants import (
     SECRET_MCP_FUNCTION_KEY,
     TOOL_AGENTIC_SEARCH,
     TOOL_DATA_ANALYST,
+    TOOL_DOCUMENT_CHAT,
     TOOL_WEB_FETCH,
     TOOL_PROGRESS_STEP,
 )
@@ -73,16 +74,16 @@ class MCPExecutor:
             return
         self.progress_streamer.emit_progress(step, STEP_MESSAGES[step], percent)
 
-    def _configure_agentic_search_args(
-        self, tool_call: Dict[str, Any], state
-    ) -> None:
+    def _configure_agentic_search_args(self, tool_call: Dict[str, Any], state) -> None:
         if tool_call["name"] == TOOL_AGENTIC_SEARCH:
             tool_call["args"].update(
                 {
                     "organization_id": self.organization_id,
                     "rewritten_query": state.rewritten_query,
                     "reranker_threshold": self.config.reranker_threshold,
-                    "historical_conversation": clean_chat_history_for_llm(state.messages),
+                    "historical_conversation": clean_chat_history_for_llm(
+                        state.messages
+                    ),
                     "web_search_threshold": self.config.web_search_results,
                 }
             )
@@ -99,11 +100,33 @@ class MCPExecutor:
 
     def _configure_web_fetch_args(self, tool_call: Dict[str, Any], state) -> None:
         if tool_call["name"] == TOOL_WEB_FETCH:
-            tool_call["args"].update(
-                {
-                    "query": state.question
-                }
-            )
+            tool_call["args"].update({"query": state.question})
+
+    def _configure_document_chat_args(self, tool_call: Dict[str, Any], state) -> None:
+        if tool_call["name"] == TOOL_DOCUMENT_CHAT:
+            current_blobs = set(state.blob_names)
+            cached_blobs = set(
+                ref.get("blob_name", "") for ref in state.uploaded_file_refs
+            )  # stored in cosmos from the last run
+
+            # Always send question and blob names
+            args = {
+                "question": state.rewritten_query,
+                "document_names": state.blob_names,
+            }
+
+            # Only send cached_file_info if blob names match exactly
+            if current_blobs == cached_blobs and state.uploaded_file_refs:
+                args["cached_file_info"] = state.uploaded_file_refs
+                logger.info(
+                    f"Blob validation passed: reusing {len(state.uploaded_file_refs)} cached files"
+                )
+            else:
+                logger.info(
+                    f"Blob validation failed: processing {len(state.blob_names)} fresh documents"
+                )
+
+            tool_call["args"].update(args)
 
     async def get_tool_calls(
         self,
@@ -111,15 +134,24 @@ class MCPExecutor:
         llm: AzureChatOpenAI,
         conversation_data: dict,
     ) -> dict:
-        logger.info(f"[MCP] Initializing MCP client")
+        # Rule-based system: Force document_chat when documents are present
+        if hasattr(state, "blob_names") and state.blob_names:
+            logger.info(
+                f"[MCP] Documents present ({len(state.blob_names)} files), forcing document_chat tool"
+            )
+            return {"mcp_tool_used": [{"name": TOOL_DOCUMENT_CHAT, "args": {}}]}
+
+        logger.info("[MCP] Initializing MCP client")
         client = await self._init_mcp_client()
 
-        logger.info(f"[MCP] Getting tools from MCP client")
+        logger.info("[MCP] Getting tools from MCP client")
         tools = await client.get_tools()
         logger.info(f"[MCP] Found {len(tools)} tools")
 
         history = conversation_data.get("history", [])
-        logger.info(f"[MCP] Retrieved {len(history)} conversation history messages for context")
+        logger.info(
+            f"[MCP] Retrieved {len(history)} conversation history messages for context"
+        )
         clean_history = clean_chat_history_for_llm(history)
         logger.info(
             f"[MCP] Cleaned conversation history: {clean_history[:200] if len(clean_history) > 200 else clean_history}"
@@ -136,7 +168,10 @@ class MCPExecutor:
         """
 
         llm_with_tools = llm.bind_tools(tools, tool_choice="any")
-        message = [SystemMessage(content=MCP_SYSTEM_PROMPT), HumanMessage(content=human_prompt)]
+        message = [
+            SystemMessage(content=MCP_SYSTEM_PROMPT),
+            HumanMessage(content=human_prompt),
+        ]
         try:
             response = await llm_with_tools.ainvoke(message)
             logger.info(
@@ -152,15 +187,15 @@ class MCPExecutor:
                 logger.info(
                     f"[MCP] Available tool names: {[tool.name for tool in tools] if tools else 'No tools'}"
                 )
-                logger.info(
-                    f"[MCP] Human prompt sent to LLM: {human_prompt[:300]}..."
-                )
+                logger.info(f"[MCP] Human prompt sent to LLM: {human_prompt[:300]}...")
         except Exception as e:
             logger.error(f"[MCP] Error getting tool calls from LLM: {str(e)}")
             raise RuntimeError(f"[MCP] Error getting tool calls from LLM: {str(e)}")
 
         return {
-            "mcp_tool_used": response.tool_calls if hasattr(response, "tool_calls") else [],
+            "mcp_tool_used": (
+                response.tool_calls if hasattr(response, "tool_calls") else []
+            ),
         }
 
     async def execute_tool_calls(self, state) -> dict:
@@ -187,6 +222,8 @@ class MCPExecutor:
                 self._configure_data_analyst_args(tool_call, state)
             elif tool_name == TOOL_WEB_FETCH:
                 self._configure_web_fetch_args(tool_call, state)
+            elif tool_name == TOOL_DOCUMENT_CHAT:
+                self._configure_document_chat_args(tool_call, state)
 
             tool = tools_by_name.get(tool_name)
             if tool:
@@ -212,4 +249,3 @@ class MCPExecutor:
             logger.info("[MCP] No tool results to return")
 
         return {"tool_results": tool_results}
-

--- a/orc/graphs/models.py
+++ b/orc/graphs/models.py
@@ -24,6 +24,8 @@ class ConversationState:
         tool_results: Results from tool execution
         code_thread_id: Thread id for the code interpreter tool
         last_mcp_tool_used: Name of the last MCP tool used
+        blob_names: List of blob names from user uploadd documents 
+        uploaded_file_refs: OpenAI file references from user uploads
     """
 
     question: str
@@ -37,3 +39,5 @@ class ConversationState:
     tool_results: List[Any] = field(default_factory=list)
     code_thread_id: Optional[str] = field(default=None)
     last_mcp_tool_used: str = field(default="")
+    blob_names: List[str] = field(default_factory=list)
+    uploaded_file_refs: List[Dict[str, str]] = field(default_factory=list)

--- a/orc/graphs/query_planner.py
+++ b/orc/graphs/query_planner.py
@@ -8,6 +8,7 @@ from orc.graphs.utils import (
     clean_chat_history_for_llm,
     extract_last_mcp_tool_from_history,
     extract_thread_id_from_history,
+    extract_uploaded_file_refs_from_history,
 )
 from shared.prompts import (
     MARKETING_ORC_PROMPT,
@@ -104,11 +105,15 @@ class QueryPlanner:
 
         existing_thread_id = extract_thread_id_from_history(history)
         existing_last_mcp_tool = extract_last_mcp_tool_from_history(history)
+        existing_uploaded_file_refs = extract_uploaded_file_refs_from_history(history)
         logger.info(
             f"[Query Rewrite] Initialized code thread_id from history: {existing_thread_id}"
         )
         logger.info(
             f"[Query Rewrite] Retrieved last_mcp_tool_used from history: {existing_last_mcp_tool}"
+        )
+        logger.info(
+            f"[Query Rewrite] Retrieved {len(existing_uploaded_file_refs)} uploaded_file_refs from history"
         )
 
         return {
@@ -121,6 +126,7 @@ class QueryPlanner:
             "messages": state.messages + [HumanMessage(content=question)],
             "code_thread_id": existing_thread_id,
             "last_mcp_tool_used": existing_last_mcp_tool,
+            "uploaded_file_refs": existing_uploaded_file_refs,
         }
 
     async def categorize(self, state, conversation_data: Dict[str, Any]) -> dict:
@@ -162,11 +168,18 @@ class QueryPlanner:
         Reply with **only** the exact category name — no additional text, explanations, or formatting.
         """
 
-        logger.info("[Query Categorization] Sending async categorization request to LLM")
-        response = await self._llm_invoke(
-            [SystemMessage(content=category_prompt), HumanMessage(content=state.question)]
+        logger.info(
+            "[Query Categorization] Sending async categorization request to LLM"
         )
-        logger.info(f"[Query Categorization] Categorized query as: '{response.content}'")
+        response = await self._llm_invoke(
+            [
+                SystemMessage(content=category_prompt),
+                HumanMessage(content=state.question),
+            ]
+        )
+        logger.info(
+            f"[Query Categorization] Categorized query as: '{response.content}'"
+        )
         return {"query_category": response.content}
 
     async def route(self, state) -> dict:
@@ -182,11 +195,16 @@ class QueryPlanner:
         """
         logger.info("[Query Routing] Sending routing decision request to LLM")
         response = await self._llm_invoke(
-            [SystemMessage(content=MARKETING_ORC_PROMPT), HumanMessage(content=human_prompt)]
+            [
+                SystemMessage(content=MARKETING_ORC_PROMPT),
+                HumanMessage(content=human_prompt),
+            ]
         )
         llm_suggests_retrieval = response.content.lower().startswith("y")
         logger.info(
             f"[Query Routing] LLM assessment - Not a casual/conversational question, proceed to retrieve documents: {llm_suggests_retrieval}"
         )
-        return {"requires_retrieval": llm_suggests_retrieval, "query_category": "General"}
-
+        return {
+            "requires_retrieval": llm_suggests_retrieval,
+            "query_category": "General",
+        }

--- a/orc/new_orchestrator.py
+++ b/orc/new_orchestrator.py
@@ -111,10 +111,12 @@ class ConversationOrchestrator:
         user_info: dict,
         user_settings: Optional[dict] = None,
         user_timezone: str | None = None,
+        blob_names: Optional[List[str]] = None,
     ):
         """Generate response with real-time progress streaming."""
         start_time = time.time()
         conversation_id = conversation_id or str(uuid.uuid4())
+        blob_names = blob_names or []
 
         logging.info(
             f"[orchestrator-generate_response] Starting streaming response for: {question[:50]}..."
@@ -166,7 +168,11 @@ class ConversationOrchestrator:
             )
 
             def run_async_agent():
-                return asyncio.run(agent.ainvoke({"question": question}, config))
+                return asyncio.run(
+                    agent.ainvoke(
+                        {"question": question, "blob_names": blob_names}, config
+                    )
+                )
 
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 future = executor.submit(run_async_agent)
@@ -196,6 +202,8 @@ class ConversationOrchestrator:
                 tool_results=response.get("tool_results", []),
                 code_thread_id=response.get("code_thread_id", None),
                 last_mcp_tool_used=response.get("last_mcp_tool_used", ""),
+                blob_names=blob_names,
+                uploaded_file_refs=response.get("uploaded_file_refs", []),
             )
 
             # Get blob URLs for images for data analyst tool
@@ -437,9 +445,9 @@ class ConversationOrchestrator:
                     "thoughts": [
                         f"""Model Used: {user_settings.get('model', 'gpt-4.1')} / Tool Selected: {state.query_category} / Original Query : {state.question} / Rewritten Query: {state.rewritten_query} / Required Retrieval: {state.requires_retrieval} / Number of documents retrieved: {len(state.context_docs) if state.context_docs else 0} / MCP Tool Used: {tool_name} / Context Retrieved using the rewritten query: / {self._format_context(state.context_docs, display_source=True)}"""
                     ],
-                    # "images_blob_urls": blob_urls,
                     "code_thread_id": state.code_thread_id,
                     "last_mcp_tool_used": state.last_mcp_tool_used,
+                    "uploaded_file_refs": state.uploaded_file_refs,
                 },
             ]
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ azure-search-documents==11.6.0b12
 langchain-mcp-adapters
 deepagents
 xhtml2pdf
+python-dotenv

--- a/shared/progress_streamer.py
+++ b/shared/progress_streamer.py
@@ -61,6 +61,7 @@ class ProgressSteps:
     AGENTIC_SEARCH = "agentic_search"
     DATA_ANALYSIS = "data_analysis"
     WEB_FETCH = "web_fetch"
+    DOCUMENT_CHAT = "document_chat"
     RESPONSE_GENERATION = "response_generation"
 
 
@@ -70,5 +71,6 @@ STEP_MESSAGES = {
     ProgressSteps.AGENTIC_SEARCH: "FreddAid is on the case - searching for answers...",
     ProgressSteps.DATA_ANALYSIS: "FreddAid's analysis gears are grinding...",
     ProgressSteps.WEB_FETCH: "FreddAid is fetching web content...",
+    ProgressSteps.DOCUMENT_CHAT: "Freddaid is searching your documents...",
     ProgressSteps.RESPONSE_GENERATION: "Composing your response...",
 }


### PR DESCRIPTION
- Added a comprehensive document chat workflow, allowing users to attach up to three documents.
- Updated the orchestrator to handle document names and manage state persistence in Cosmos DB.
- Enhanced the context builder and MCP executor to support document chat responses and file reference management.
- Included detailed documentation outlining the workflow, storage layout, and implementation specifics.